### PR TITLE
Fix https issues.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,6 +2,6 @@ Copyright 2011-2014 Analytical Graphics Inc. and Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ Copyright 2011-2014 Analytical Graphics Inc. and Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy
-of the License at:  http://www.apache.org/licenses/LICENSE-2.0
+of the License at:  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -213,8 +213,8 @@ specific language governing permissions and limitations under the License.
 		<p>
 			Check out <a href="http://get.webgl.org/">Get WebGL</a>,
 			or try installing the latest version of
-			<a href="http://www.google.com/chrome">Chrome</a>, or
-				<a href="http://www.mozilla.org/en-US/firefox/">Firefox</a>.
+			<a href="https://www.google.com/chrome">Chrome</a>, or
+				<a href="https://www.mozilla.org/en-US/firefox/">Firefox</a>.
 		</p>
 	</script>
 
@@ -224,8 +224,8 @@ specific language governing permissions and limitations under the License.
 		<p>
 			Also check out <a href="http://get.webgl.org/">Get WebGL</a>,
 			or try installing the latest version of
-			<a href="http://www.google.com/chrome">Chrome</a>, or
-				<a href="http://www.mozilla.org/en-US/firefox/">Firefox</a>.
+			<a href="https://www.google.com/chrome">Chrome</a>, or
+				<a href="https://www.mozilla.org/en-US/firefox/">Firefox</a>.
 		</p>
 	</script>
 

--- a/webglreport.js
+++ b/webglreport.js
@@ -65,7 +65,7 @@ $(function() {
         extension = extension.replace(/^MOZ_/, '');
         extension = extension.replace(/_EXT_/, '_');
 
-        return 'http://www.khronos.org/registry/webgl/extensions/' + extension;
+        return 'https://www.khronos.org/registry/webgl/extensions/' + extension;
     }
 
     function renderReport(header) {
@@ -86,7 +86,7 @@ $(function() {
 
         if (e) {
             var max = gl.getParameter(e.MAX_TEXTURE_MAX_ANISOTROPY_EXT);
-            // See Canary bug: http://code.google.com/p/chromium/issues/detail?id=117450
+            // See Canary bug: https://code.google.com/p/chromium/issues/detail?id=117450
             if (max === 0) {
                 max = 2;
             }


### PR DESCRIPTION
Thanks for the cool and useful site. Here's a couple of patches to https-ify things. Only the first one is necessary to make https://analyticalgraphicsinc.github.io/webglreport/ work.

It's better to use encrypted transports when possible, given all the traffic interception that's going on..
