### PR TITLE
Displayed max draw buffer count

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,10 @@ specific language governing permissions and limitations under the License.
 							<h1>Framebuffer</h1>
 							<table>
 								<tr>
+									<th>Max Color Buffers:</th>
+									<td><%= report.maxColorBuffers %></td>
+								</tr>
+								<tr>
 									<th>RGBA Bits:</th>
 									<td>[<%= report.redBits %>, <%= report.greenBits %>, <%= report.blueBits %>, <%= report.alphaBits %>]</td>
 								</tr>

--- a/webglreport.js
+++ b/webglreport.js
@@ -190,6 +190,15 @@ $(function() {
         return '';
     }
 
+    function getMaxColorBuffers(gl) {
+        var maxColorBuffers = 1;
+        var ext = gl.getExtension("WEBGL_draw_buffers");
+		if (ext != null) 
+    		maxColorBuffers = gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL);
+        
+        return maxColorBuffers;
+    }
+
     report = _.extend(report, {
         contextName: contextName,
         glVersion: gl.getParameter(gl.VERSION),
@@ -199,6 +208,7 @@ $(function() {
         antialias:  gl.getContextAttributes().antialias ? 'Available' : 'Not available',
         angle: getAngle(gl),
         majorPerformanceCaveat: getMajorPerformanceCaveat(contextName),
+        maxColorBuffers: getMaxColorBuffers(gl),
         redBits: gl.getParameter(gl.RED_BITS),
         greenBits: gl.getParameter(gl.GREEN_BITS),
         blueBits: gl.getParameter(gl.BLUE_BITS),


### PR DESCRIPTION
The value of MAX_DRAW_BUFFERS_WEBGL is dependent on the implementation.
Added the value to the displayed name of the extension
WEBGL_draw_buffers.
