### PR TITLE
Added unmasked vendor and renderer info

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,18 @@ specific language governing permissions and limitations under the License.
 				<th>Renderer:</th>
 				<td><%= report.renderer %></td>
 			</tr>
+            <% if (report.unMaskedVendor !== '') { %>
+			<tr>
+				<th>Unmasked Vendor:</th>
+				<td><%= report.unMaskedVendor %></td>
+			</tr>
+            <% } %>
+            <% if (report.unMaskedRenderer !== '') { %>
+			<tr>
+				<th>Unmasked Renderer:</th>
+				<td><%= report.unMaskedRenderer %></td>
+			</tr>
+            <% } %>
 			<tr>
 				<th>Antialiasing:</th>
 				<td><%= report.antialias %></td>

--- a/webglreport.js
+++ b/webglreport.js
@@ -199,12 +199,29 @@ $(function() {
         return maxColorBuffers;
     }
 
+    function getUnmaskedInfo(gl) {
+        var unMaskedInfo = {
+            renderer: '',
+            vendor: ''
+        };
+        
+        var dbgRenderInfo = gl.getExtension("WEBGL_debug_renderer_info");
+        if (dbgRenderInfo != null) {
+            unMaskedInfo.renderer = gl.getParameter(dbgRenderInfo.UNMASKED_RENDERER_WEBGL);
+            unMaskedInfo.vendor   = gl.getParameter(dbgRenderInfo.UNMASKED_VENDOR_WEBGL);
+        }
+        
+        return unMaskedInfo;
+    }
+    
     report = _.extend(report, {
         contextName: contextName,
         glVersion: gl.getParameter(gl.VERSION),
         shadingLanguageVersion: gl.getParameter(gl.SHADING_LANGUAGE_VERSION),
         vendor: gl.getParameter(gl.VENDOR),
         renderer: gl.getParameter(gl.RENDERER),
+        unMaskedVendor: getUnmaskedInfo(gl).vendor,
+        unMaskedRenderer: getUnmaskedInfo(gl).renderer,
         antialias:  gl.getContextAttributes().antialias ? 'Available' : 'Not available',
         angle: getAngle(gl),
         majorPerformanceCaveat: getMajorPerformanceCaveat(contextName),


### PR DESCRIPTION
Display unmasked vendor and renderer info if the extension
WEBGL_debug_renderer_info is available.
