### PR TITLE
Added webgl2 context creation

### DIFF
--- a/webglreport.js
+++ b/webglreport.js
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2011-2013 Contributors.
+Copyright 2011-2014 Analytical Graphics Inc. and Contributors
 
 The MIT License
 
@@ -41,7 +41,7 @@ $(function() {
 
     var canvas = $('<canvas />', { width: '1', height: '1' }).appendTo('body');
     var gl;
-    var contextName = _.find(['webgl', 'experimental-webgl'], function(name) {
+    var contextName = _.find(['experimental-webgl2', 'webgl', 'experimental-webgl'], function(name) {
         gl = canvas[0].getContext(name, { stencil: true });
         return !!gl;
     });


### PR DESCRIPTION
Enabling in Firefox: https://wiki.mozilla.org/Platform/GFX/WebGL2

I was hoping that uniform buffer functions would be exposed on the GL context itself or as an extension, but that does not appear to be the case yet. :disappointed: 