### PR TITLE
WebGL 2 tab and pipeline

### DIFF
--- a/black.css
+++ b/black.css
@@ -140,7 +140,13 @@ th {
     width: 100%;
 }
 
-.pipeline .vertexShader, .pipeline .rasterizer, .pipeline .fragmentShader, .pipeline .framebuffer, .pipeline .textures {
+.pipeline .vertexShader,
+.pipeline .transformFeedback,
+.pipeline .rasterizer,
+.pipeline .fragmentShader,
+.pipeline .framebuffer,
+.pipeline .textures,
+.pipeline .uniformBuffers {
     position: absolute;
     width: 265px;
 }
@@ -155,24 +161,39 @@ th {
     left: 5px;
 }
 
-.pipeline .rasterizer {
-    top: 220px;
+.pipeline .transformFeedback {
+    top: 215px;
     left: 5px;
 }
 
-.pipeline .fragmentShader {
+.pipeline .rasterizer {
     top: 350px;
     left: 5px;
 }
 
-.pipeline .framebuffer {
-    top: 520px;
+.pipeline .fragmentShader {
+    top: 460px;
     left: 5px;
 }
 
-.pipeline .textures {
-    top: 200px;
+.pipeline .framebuffer {
+    top: 475px;
     left: 360px;
+}
+
+.pipeline .textures {
+    top: 120px;
+    left: 360px;
+}
+
+.pipeline .uniformBuffers {
+    top: 260px;
+    left: 360px;
+}
+
+.pipeline a,
+.pipeline a:visited {
+    color: #fff;
 }
 
 a.extension {
@@ -181,6 +202,11 @@ a.extension {
 
 a.unsupported {
     color: rgb(200, 200, 200);
+}
+
+.comingSoon {
+    text-align: center;
+    padding: 10px;
 }
 
 @media only screen and (min-width:1470px) {

--- a/black.css
+++ b/black.css
@@ -62,20 +62,21 @@ body {
 .webglVersionTabs a.active,
 .webglVersionTabs a.active:visited {
     background-color: #00A900;
-    color: #42CEFF;
+    color: #FFF;
     padding: 8px 15px;
 }
 
 .warn .webglVersionTabs a.active,
 .warn .webglVersionTabs a.active:visited {
     background-color: #A90000;
-    color: #42CEFF;
+    color: #FFF;
 }
 
 .header {
     background: #00A900;
     overflow: hidden;
     margin-bottom: 8px;
+    padding: 0 5px;
 }
 
 .warn .header {

--- a/black.css
+++ b/black.css
@@ -194,7 +194,7 @@ th {
 }
 
 .webgl2 .pipeline .framebuffer {
-    top: 530px;
+    top: 550px;
     left: 360px;
 }
 
@@ -210,6 +210,10 @@ th {
 .pipeline .uniformBuffers {
     top: 300px;
     left: 360px;
+}
+
+.webgl2 .pipeline .uniformBuffers {
+    top: 345px;
 }
 
 .pipeline a,

--- a/black.css
+++ b/black.css
@@ -107,7 +107,7 @@ img {
     width: 100%;
     color: black;
     box-sizing: border-box;
-    font-size: 9pt;
+    font-size: 12px;
     text-align: left;
     border-style: ridge;
     border-width: 3px;
@@ -134,6 +134,10 @@ th {
     height: 660px;
     color: white;
     position: relative;
+}
+
+.webgl2 .pipeline {
+    height: 730px;
 }
 
 .pipeline table {
@@ -171,9 +175,17 @@ th {
     left: 5px;
 }
 
+.webgl2 .pipeline .rasterizer {
+    top: 320px;
+}
+
 .pipeline .fragmentShader {
     top: 335px;
     left: 5px;
+}
+
+.webgl2 .pipeline .fragmentShader {
+    top: 435px;
 }
 
 .pipeline .framebuffer {
@@ -181,9 +193,18 @@ th {
     left: 5px;
 }
 
+.webgl2 .pipeline .framebuffer {
+    top: 530px;
+    left: 360px;
+}
+
 .pipeline .textures {
     top: 140px;
     left: 360px;
+}
+
+.webgl2 .pipeline .textures {
+    top: 150px;
 }
 
 .pipeline .uniformBuffers {
@@ -214,14 +235,17 @@ a.unsupported {
         width: 1365px;
     }
     .report {
-        min-height: 660px;
+        min-height: 680px;
+    }
+    .webgl2 .report {
+        min-height: 750px;
     }
     .warn .report {
         min-height: 0;
     }
     .pipeline {
         position: absolute;
-        top: 0;
+        top: 5px;
         right: 0;
     }
 }

--- a/black.css
+++ b/black.css
@@ -36,10 +36,15 @@ body {
 }
 
 .main-output {
+    position: relative;
     margin-left: auto;
     margin-right: auto;
     width: 700px;
     text-align: center;
+}
+
+.main-left-column {
+    width: 190px;
 }
 
 .webglVersionTabs {
@@ -97,11 +102,11 @@ img {
     text-align: center;
 }
 
-table.report {
-    margin-left: auto;
-    margin-right: auto;
-    width: 700px;
+.report {
+    position: relative;
+    width: 100%;
     color: black;
+    box-sizing: border-box;
     font-size: 9pt;
     text-align: left;
     border-style: ridge;
@@ -109,6 +114,10 @@ table.report {
     padding: 6px;
     border-color: #AFC7C7;
     background-color: #FFFFFF;
+}
+
+.report > table {
+    width: 700px;
 }
 
 td, th {
@@ -121,7 +130,7 @@ th {
 }
 
 .pipeline {
-    width: 600px;
+    width: 660px;
     height: 660px;
     color: white;
     position: relative;
@@ -133,7 +142,7 @@ th {
 
 .pipeline .vertexShader, .pipeline .rasterizer, .pipeline .fragmentShader, .pipeline .framebuffer, .pipeline .textures {
     position: absolute;
-    width: 245px;
+    width: 265px;
 }
 
 .pipeline h1 {
@@ -163,7 +172,7 @@ th {
 
 .pipeline .textures {
     top: 200px;
-    left: 330px;
+    left: 360px;
 }
 
 a.extension {
@@ -172,4 +181,18 @@ a.extension {
 
 a.unsupported {
     color: rgb(200, 200, 200);
+}
+
+@media only screen and (min-width:1470px) {
+    .main-output {
+        width: 1365px;
+    }
+    .report {
+        min-height: 660px;
+    }
+    .pipeline {
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
 }

--- a/black.css
+++ b/black.css
@@ -20,6 +20,7 @@ h1 {
 
 body {
     font-family: arial, Sans-Serif;
+    font-size: 16px;
     color: white;
     background-image: url(images/mtimoon_fromSTK_3d.jpg);
     background-position: right top;
@@ -32,6 +33,60 @@ body {
     margin-left: auto;
     margin-right: auto;
     text-align: center;
+}
+
+.main-output {
+    margin-left: auto;
+    margin-right: auto;
+    width: 700px;
+    text-align: center;
+}
+
+.webglVersionTabs {
+    text-align: left;
+    padding-left: 4px;
+    font-size: 20px;
+}
+
+.webglVersionTabs a,
+.webglVersionTabs a:visited {
+    display: inline-block;
+    background-color: #ddd;
+    padding: 5px 10px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    vertical-align: bottom;
+    color: #218bb0;
+}
+
+.webglVersionTabs a.active,
+.webglVersionTabs a.active:visited {
+    background-color: #00A900;
+    color: #42CEFF;
+    padding: 8px 15px;
+}
+
+.warn .webglVersionTabs a.active,
+.warn .webglVersionTabs a.active:visited {
+    background-color: #A90000;
+    color: #42CEFF;
+}
+
+.header {
+    background: #00A900;
+    overflow: hidden;
+    margin-bottom: 8px;
+}
+
+.warn .header {
+    background: #A90000;
+}
+
+.header a,
+.header a:visited,
+.warn .header a,
+.warn .header a:visited {
+    color: #42CEFF;
 }
 
 img {

--- a/black.css
+++ b/black.css
@@ -162,32 +162,32 @@ th {
 }
 
 .pipeline .transformFeedback {
-    top: 215px;
-    left: 5px;
+    top: 10px;
+    left: 360px;
 }
 
 .pipeline .rasterizer {
-    top: 350px;
+    top: 220px;
     left: 5px;
 }
 
 .pipeline .fragmentShader {
-    top: 460px;
+    top: 335px;
     left: 5px;
 }
 
 .pipeline .framebuffer {
-    top: 475px;
-    left: 360px;
+    top: 520px;
+    left: 5px;
 }
 
 .pipeline .textures {
-    top: 120px;
+    top: 140px;
     left: 360px;
 }
 
 .pipeline .uniformBuffers {
-    top: 260px;
+    top: 300px;
     left: 360px;
 }
 
@@ -215,6 +215,9 @@ a.unsupported {
     }
     .report {
         min-height: 660px;
+    }
+    .warn .report {
+        min-height: 0;
     }
     .pipeline {
         position: absolute;

--- a/index.html
+++ b/index.html
@@ -94,6 +94,24 @@
                                     <th>Best float precision:</th>
                                     <td><%= report.vertexShaderBestPrecision %></td>
                                 </tr>
+                                <% if (report.webglVersion > 1) { %>
+                                <tr>
+                                    <th>Max Vertex Uniform Components:</th>
+                                    <td><%= report.maxVertexUniformComponents %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Vertex Uniform Blocks:</th>
+                                    <td><%= report.maxVertexUniformBlocks %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Vertex Output Components:</th>
+                                    <td><%= report.maxVertexOutputComponents %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Varying Components:</th>
+                                    <td><%= report.maxVaryingComponents %></td>
+                                </tr>
+                                <% } %>
                             </table>
                         </div>
                         <div class="transformFeedback">
@@ -104,15 +122,15 @@
                             </div>
                             <% } else { %>
                             <table>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Interleaved Components:</th>
                                     <td><%= report.maxTransformFeedbackInterleavedComponents %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Separate Attribs:</th>
                                     <td><%= report.maxTransformFeedbackSeparateAttribs %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Separate Components:</th>
                                     <td><%= report.maxTransformFeedbackSeparateComponents %></td>
                                 </tr>
@@ -151,15 +169,52 @@
                                     <th>Best float precision:</th>
                                     <td><%= report.fragmentShaderBestPrecision %></td>
                                 </tr>
+                                <% if (report.webglVersion > 1) { %>
+                                <tr>
+                                    <th>Max Fragment Uniform Components:</th>
+                                    <td><%= report.maxFragmentUniformComponents %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Fragment Uniform Blocks:</th>
+                                    <td><%= report.maxFragmentUniformBlocks %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Fragment Input Components:</th>
+                                    <td><%= report.maxFragmentInputComponents %></td>
+                                </tr>
+                                <tr>
+                                    <th>Min Program Texel Offset:</th>
+                                    <td><%= report.minProgramTexelOffset %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Program Texel Offset:</th>
+                                    <td><%= report.maxProgramTexelOffset %></td>
+                                </tr>
+                                <% } %>
                             </table>
                         </div>
                         <div class="framebuffer">
                             <h1>Framebuffer</h1>
                             <table>
+                                <% if (report.webglVersion > 1) { %>
+                                <tr>
+                                    <th>Max Draw Buffers:</th>
+                                    <td><%= report.maxDrawBuffers %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Color Attachments:</th>
+                                    <td><%= report.maxColorAttachments %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Samples:</th>
+                                    <td><%= report.maxSamples %></td>
+                                </tr>
+                                <% } else { %>
                                 <tr>
                                     <th>Max Color Buffers:</th>
                                     <td><%= report.maxColorBuffers %></td>
                                 </tr>
+                                <% } %>
                                 <tr>
                                     <th>RGBA Bits:</th>
                                     <td>[<%= report.redBits %>, <%= report.greenBits %>, <%= report.blueBits %>, <%= report.alphaBits %>]</td>
@@ -209,27 +264,27 @@
                             </div>
                             <% } else { %>
                             <table>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Uniform Buffer Bindings:</th>
                                     <td><%= report.maxUniformBufferBindings %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Uniform Block Size:</th>
                                     <td><%= report.maxUniformBlockSize %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Uniform Buffer Offset Alignment:</th>
                                     <td><%= report.uniformBufferOffsetAlignment %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Combined Uniform Blocks:</th>
                                     <td><%= report.maxCombinedUniformBlocks %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Combined Vertex Uniform Components:</th>
                                     <td><%= report.maxCombinedVertexUniformComponents %></td>
                                 </tr>
-                                <tr title="Minimum: ???">
+                                <tr>
                                     <th>Max Combined Fragment Uniform Components:</th>
                                     <td><%= report.maxCombinedFragmentUniformComponents %></td>
                                 </tr>

--- a/index.html
+++ b/index.html
@@ -248,10 +248,22 @@
                                     <th>Max Combined Texture Image Units:</th>
                                     <td><%= report.maxCombinedTextureImageUnits %></td>
                                 </tr>
-                                <% if (report.maxAnisotropy) { %>
                                 <tr title="Minimum: 2">
                                     <th>Max Anisotropy:</th>
                                     <td><%= report.maxAnisotropy %></td>
+                                </tr>
+                                <% if (report.webglVersion > 1) { %>
+                                <tr>
+                                    <th>Max 3D Texture Size:</th>
+                                    <td><%= report.max3dTextureSize %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Array Texture Layers:</th>
+                                    <td><%= report.maxArrayTextureLayers %></td>
+                                </tr>
+                                <tr>
+                                    <th>Max Texture LOD Bias:</th>
+                                    <td><%= report.maxTextureLodBias %></td>
                                 </tr>
                                 <% } %>
                             </table>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,9 @@
 </head>
 <body>
     <script type="text/template" id="reportTemplate">
-        <table class="report">
-            <colgroup>
-                <col width="35%" />
-                <col />
-            </colgroup>
+        <div class="report"><table>
             <tr>
-                <th>Platform:</th>
+                <th class="main-left-column">Platform:</th>
                 <td><%= report.platform %></td>
             </tr>
             <tr>
@@ -222,7 +218,7 @@
             <% }); %>
             <% } %>
             <% } %>
-        </table>
+        </table></div>
     </script>
 
     <script type="text/template" id="webglSupportedTemplate">

--- a/index.html
+++ b/index.html
@@ -202,6 +202,7 @@
                     <%= report.draftExtensionsInstructions %>
                 </td>
             </tr>
+            <% if (report.webglVersion === 2) { %>
             <tr>
                 <th colspan="2"><br /><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/">WebGL 2</a> Functions Implementation Status:</th>
             </tr>
@@ -218,12 +219,8 @@
                         <a class="<%= e.className %>" href="<%= getWebGL2ExtensionUrl(e.name) %>"><%= e.name %></a>
                     </td>
                 </tr>
-            <% }) %>
-            <tr>
-                <td colspan="2">
-                    <%= report.webgl2Instructions %>
-                </td>
-            </tr>
+            <% }); %>
+            <% } %>
             <% } %>
         </table>
     </script>
@@ -243,12 +240,18 @@
     <script type="text/template" id="webglNotSupportedTemplate">
         <div class="header">
             <p>&times; This browser does not support WebGL <%= report.webglVersion %></p>
+            <% if (report.webglVersion === 2 && report.userAgent.indexOf('Firefox') !== -1) { %>
+            <p>
+                To enable WebGL 2 in Firefox, see <a href="https://wiki.mozilla.org/Platform/GFX/WebGL2">https://wiki.mozilla.org/Platform/GFX/WebGL2</a>.
+            </p>
+            <% } else { %>
             <p>
                 Check out <a href="http://get.webgl.org/">Get WebGL</a>,
                 or try installing the latest version of
                 <a href="https://www.google.com/chrome">Chrome</a>, or
                 <a href="https://www.mozilla.org/en-US/firefox/">Firefox</a>.
             </p>
+            <% } %>
         </div>
     </script>
 

--- a/index.html
+++ b/index.html
@@ -105,16 +105,16 @@
                             <% } else { %>
                             <table>
                                 <tr title="Minimum: ???">
-                                    <th>Max Interleaved Componment:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <th>Max Interleaved Components:</th>
+                                    <td><%= report.maxTransformFeedbackInterleavedComponents %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Max Separate Attribs:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxTransformFeedbackSeparateAttribs %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Max Separate Components:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxTransformFeedbackSeparateComponents %></td>
                                 </tr>
                             </table>
                             <% } %>
@@ -211,27 +211,27 @@
                             <table>
                                 <tr title="Minimum: ???">
                                     <th>Max Uniform Buffer Bindings:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxUniformBufferBindings %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Max Uniform Block Size:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxUniformBlockSize %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Uniform Buffer Offset Alignment:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.uniformBufferOffsetAlignment %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Max Combined Uniform Blocks:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxCombinedUniformBlocks %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Max Combined Vertex Uniform Components:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxCombinedVertexUniformComponents %></td>
                                 </tr>
                                 <tr title="Minimum: ???">
                                     <th>Max Combined Fragment Uniform Components:</th>
-                                    <td><%= report.maxTextureSize %></td>
+                                    <td><%= report.maxCombinedFragmentUniformComponents %></td>
                                 </tr>
                             </table>
                             <% } %>

--- a/index.html
+++ b/index.html
@@ -96,6 +96,29 @@
                                 </tr>
                             </table>
                         </div>
+                        <div class="transformFeedback">
+                            <h1>Transform Feedback</h1>
+                            <% if (report.webglVersion < 2) { %>
+                            <div class="comingSoon">
+                                Coming in <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/">WebGL 2</a>
+                            </div>
+                            <% } else { %>
+                            <table>
+                                <tr title="Minimum: ???">
+                                    <th>Max Interleaved Componment:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Max Separate Attribs:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Max Separate Components:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                            </table>
+                            <% } %>
+                        </div>
                         <div class="rasterizer">
                             <h1>Rasterizer</h1>
                             <table>
@@ -177,6 +200,41 @@
                                 </tr>
                                 <% } %>
                             </table>
+                        </div>
+                        <div class="uniformBuffers">
+                            <h1>Uniform Buffers</h1>
+                            <% if (report.webglVersion < 2) { %>
+                            <div class="comingSoon">
+                                Coming in <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/">WebGL 2</a>
+                            </div>
+                            <% } else { %>
+                            <table>
+                                <tr title="Minimum: ???">
+                                    <th>Max Uniform Buffer Bindings:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Max Uniform Block Size:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Uniform Buffer Offset Alignment:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Max Combined Uniform Blocks:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Max Combined Vertex Uniform Components:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                                <tr title="Minimum: ???">
+                                    <th>Max Combined Fragment Uniform Components:</th>
+                                    <td><%= report.maxTextureSize %></td>
+                                </tr>
+                            </table>
+                            <% } %>
                         </div>
                     </div>
                 </td>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,10 @@
 <body>
     <script type="text/template" id="reportTemplate">
         <table class="report">
-            <col width="35%" />
-            <col />
+            <colgroup>
+                <col width="35%" />
+                <col />
+            </colgroup>
             <tr>
                 <th>Platform:</th>
                 <td><%= report.platform %></td>
@@ -227,32 +229,47 @@
     </script>
 
     <script type="text/template" id="webglSupportedTemplate">
-        <p>This browser supports WebGL.</p>
+        <div class="header">
+            <p>&#x2713; This browser supports WebGL <%= report.webglVersion %></p>
+        </div>
     </script>
 
     <script type="text/template" id="webglSupportedChromeFrameTemplate">
-        <p>This browser supports WebGL with Chrome Frame.</p>
+        <div class="header">
+            <p>&#x2713; This browser supports WebGL <%= report.webglVersion %> with Chrome Frame.</p>
+        </div>
     </script>
 
     <script type="text/template" id="webglNotSupportedTemplate">
-        <p>This browser does not support WebGL.</p>
-        <p>
-            Check out <a href="http://get.webgl.org/">Get WebGL</a>,
-            or try installing the latest version of
-            <a href="https://www.google.com/chrome">Chrome</a>, or
+        <div class="header">
+            <p>&times; This browser does not support WebGL <%= report.webglVersion %></p>
+            <p>
+                Check out <a href="http://get.webgl.org/">Get WebGL</a>,
+                or try installing the latest version of
+                <a href="https://www.google.com/chrome">Chrome</a>, or
                 <a href="https://www.mozilla.org/en-US/firefox/">Firefox</a>.
-        </p>
+            </p>
+        </div>
     </script>
 
     <script type="text/template" id="webglNotEnabledTemplate">
-        <p>This browser supports WebGL, but it is disabled or unavailable.</p>
-        <p>Sometimes this is the result of older video drivers being rejected by the browser.  Try updating your video drivers if possible.</p>
-        <p>
-            Also check out <a href="http://get.webgl.org/">Get WebGL</a>,
-            or try installing the latest version of
-            <a href="https://www.google.com/chrome">Chrome</a>, or
+        <div class="header">
+            <p>&times; This browser supports WebGL <%= report.webglVersion %>, but it is disabled or unavailable.</p>
+            <p>Sometimes this is the result of older video drivers being rejected by the browser.  Try updating your video drivers if possible.</p>
+            <p>
+                Also check out <a href="http://get.webgl.org/">Get WebGL</a>,
+                or try installing the latest version of
+                <a href="https://www.google.com/chrome">Chrome</a>, or
                 <a href="https://www.mozilla.org/en-US/firefox/">Firefox</a>.
-        </p>
+            </p>
+        </div>
+    </script>
+
+    <script type="text/template" id="webglVersionTabs">
+        <div class="webglVersionTabs">
+            <a href="?v=1" class="<%= report.webglVersion === 1 ? 'active' : '' %>">WebGL 1</a>
+            <a href="?v=2" class="<%= report.webglVersion === 2 ? 'active' : '' %>">WebGL 2</a>
+        </div>
     </script>
 
     <a href="https://github.com/AnalyticalGraphicsInc/webglreport" target="_blank"><img style="position: absolute; top: 0; left: 0; border: 0;" src="images/ForkMe_Ribbons/ForkMe_Blk.png" alt="Fork me on GitHub"></a>
@@ -261,7 +278,7 @@
 
     <p id="javascript_disabled" class="align-center">You need to enable JavaScript to see WebGL.</p>
 
-    <div class="align-center" id="output">
+    <div class="main-output" id="output">
     </div>
 
     <script type="text/javascript">

--- a/webglreport.js
+++ b/webglreport.js
@@ -4,14 +4,19 @@
 $(function() {
     "use strict";
 
+    var webglVersion = window.location.search.indexOf('v=2') > 0 ? 2 : 1;
+
     var template = _.template($('#reportTemplate').html());
     var report = {
         platform: navigator.platform,
-        userAgent: navigator.userAgent
+        userAgent: navigator.userAgent,
+        webglVersion: webglVersion
     };
 
-    if (!window.WebGLRenderingContext) {
+    if ((webglVersion === 2 && !window.WebGL2RenderingContext) ||
+        (webglVersion === 1 && !window.WebGLRenderingContext)) {
         // The browser does not support WebGL
+        $('#output').addClass('warn');
         renderReport($('#webglNotSupportedTemplate').html());
         return;
     }
@@ -26,6 +31,7 @@ $(function() {
 
     if (!gl) {
         // The browser supports WebGL, but initialization failed
+        $('#output').addClass('warn');
         renderReport($('#webglNotEnabledTemplate').html());
         return;
     }
@@ -46,7 +52,13 @@ $(function() {
     }
 
     function renderReport(header) {
-        $('#output').html(header + template({
+        var tabsTemplate = _.template($('#webglVersionTabs').html());
+        var headerTemplate = _.template(header);
+        $('#output').html(tabsTemplate({
+            report: report,
+        }) + headerTemplate({
+            report: report,
+        }) + template({
             report: report,
             getExtensionUrl: getExtensionUrl,
             getWebGL2ExtensionUrl: getWebGL2ExtensionUrl

--- a/webglreport.js
+++ b/webglreport.js
@@ -13,6 +13,10 @@ $(function() {
         webglVersion: webglVersion
     };
 
+    if (webglVersion === 2) {
+        $('body').addClass('webgl2');
+    }
+
     if ((webglVersion === 2 && !window.WebGL2RenderingContext) ||
         (webglVersion === 1 && !window.WebGLRenderingContext)) {
         // The browser does not support WebGL
@@ -206,7 +210,7 @@ $(function() {
     }
 
     function showNull(v) {
-        return (v === null) ? 'null' : v;
+        return (v === null) ? 'n/a' : v;
     }
     
     var webglToEsNames = {
@@ -555,12 +559,12 @@ $(function() {
         drawDownHead(arrowBottomX, arrowBottomY);
     }
 
-    function drawRightArrow(leftBox, rightBox) {
+    function drawRightArrow(leftBox, rightBox, factor) {
         context.beginPath();
 
         var arrowLeftX = leftBox.x + leftBox.width;
         var arrowRightX = rightBox.x - 15;
-        var arrowRightY = rightBox.y + rightBox.height * 0.30;
+        var arrowRightY = rightBox.y + rightBox.height * factor;
         context.moveTo(arrowLeftX, arrowRightY);
         context.lineTo(arrowRightX, arrowRightY);
         context.stroke();
@@ -582,7 +586,7 @@ $(function() {
     var arrowRightY = texturesBox.y + (texturesBox.height / 2);
     var arrowMidX = (texturesBox.x + vertexShaderBox.x + vertexShaderBox.width) / 2;
     var arrowMidY = arrowRightY;
-    var arrowTopMidY = vertexShaderBox.y + (vertexShaderBox.height / 2);
+    var arrowTopMidY = texturesBox.y - 15;
     var arrowBottomMidY = fragmentShaderBox.y + (fragmentShaderBox.height * 0.55);
     var arrowTopLeftX = vertexShaderBox.x + vertexShaderBox.width + 15;
     var arrowTopLeftY = arrowTopMidY;
@@ -634,10 +638,14 @@ $(function() {
 
     drawLeftHead(arrowBottomLeftX, arrowBottomLeftY);
 
-    drawRightArrow(vertexShaderBox, transformFeedbackBox);
+    drawRightArrow(vertexShaderBox, transformFeedbackBox, 0.5);
     drawDownArrow(vertexShaderBox, rasterizerBox);
     drawDownArrow(rasterizerBox, fragmentShaderBox);
-    drawDownArrow(fragmentShaderBox, framebufferBox);
+    if (webglVersion === 1) {
+        drawDownArrow(fragmentShaderBox, framebufferBox);
+    } else {
+        drawRightArrow(fragmentShaderBox, framebufferBox, 0.7);
+    }
 
     window.gl = gl;
 });

--- a/webglreport.js
+++ b/webglreport.js
@@ -23,7 +23,8 @@ $(function() {
 
     var canvas = $('<canvas />', { width: '1', height: '1' }).appendTo('body');
     var gl;
-    var contextName = _.find(['webgl2', 'experimental-webgl2', 'webgl', 'experimental-webgl'], function(name) {
+    var possibleNames = (webglVersion === 2) ? ['webgl2', 'experimental-webgl2'] : ['webgl', 'experimental-webgl'];
+    var contextName = _.find(possibleNames, function (name) {
         gl = canvas[0].getContext(name, { stencil: true });
         return !!gl;
     });
@@ -356,7 +357,6 @@ $(function() {
         ];
 
         var webgl2 = (contextName.indexOf('webgl2') !== -1);
-        var instructions = '';
 
         var functions = [];
         var totalImplemented = 0;
@@ -373,17 +373,12 @@ $(function() {
                 }
                 functions.push({ name: name, className: className });
             }
-        } else {
-            if (navigator.userAgent.indexOf('Firefox') !== -1) {
-                instructions = 'To enable WebGL 2 in Firefox, see <a href="https://wiki.mozilla.org/Platform/GFX/WebGL2">https://wiki.mozilla.org/Platform/GFX/WebGL2</a>.';
-            }
         }
 
         return {
             status : webgl2 ? (totalImplemented + ' of ' + length + ' new functions implemented.') :
                 'webgl2 and experimental-webgl2 contexts not available.',
-            functions : functions,
-            instructions : instructions
+            functions : functions
         };
     }
 
@@ -429,8 +424,7 @@ $(function() {
         draftExtensionsInstructions: getDraftExtensionsInstructions(),
 
         webgl2Status : webgl2Status.status,
-        webgl2Functions : webgl2Status.functions,
-        webgl2Instructions : webgl2Status.instructions
+        webgl2Functions : webgl2Status.functions
     });
 
     if (window.externalHost) {

--- a/webglreport.js
+++ b/webglreport.js
@@ -525,7 +525,7 @@ $(function() {
 
         var arrowLeftX = leftBox.x + leftBox.width;
         var arrowRightX = rightBox.x - 15;
-        var arrowRightY = rightBox.y + rightBox.height * 0.70;
+        var arrowRightY = rightBox.y + rightBox.height * 0.30;
         context.moveTo(arrowLeftX, arrowRightY);
         context.lineTo(arrowRightX, arrowRightY);
         context.stroke();
@@ -548,7 +548,7 @@ $(function() {
     var arrowMidX = (texturesBox.x + vertexShaderBox.x + vertexShaderBox.width) / 2;
     var arrowMidY = arrowRightY;
     var arrowTopMidY = vertexShaderBox.y + (vertexShaderBox.height / 2);
-    var arrowBottomMidY = fragmentShaderBox.y + (fragmentShaderBox.height * 0.33);
+    var arrowBottomMidY = fragmentShaderBox.y + (fragmentShaderBox.height * 0.55);
     var arrowTopLeftX = vertexShaderBox.x + vertexShaderBox.width + 15;
     var arrowTopLeftY = arrowTopMidY;
     var arrowBottomLeftX = fragmentShaderBox.x + fragmentShaderBox.width + 15;
@@ -599,8 +599,8 @@ $(function() {
 
     drawLeftHead(arrowBottomLeftX, arrowBottomLeftY);
 
-    drawDownArrow(vertexShaderBox, transformFeedbackBox);
-    drawDownArrow(transformFeedbackBox, rasterizerBox);
+    drawRightArrow(vertexShaderBox, transformFeedbackBox);
+    drawDownArrow(vertexShaderBox, rasterizerBox);
     drawDownArrow(rasterizerBox, fragmentShaderBox);
-    drawRightArrow(fragmentShaderBox, framebufferBox);
+    drawDownArrow(fragmentShaderBox, framebufferBox);
 });

--- a/webglreport.js
+++ b/webglreport.js
@@ -204,6 +204,10 @@ $(function() {
         
         return unMaskedInfo;
     }
+
+    function showNull(v) {
+        return (v === null) ? 'null' : v;
+    }
     
     var webglToEsNames = {
         'getInternalformatParameter' : 'getInternalformativ',
@@ -427,6 +431,37 @@ $(function() {
         webgl2Functions : webgl2Status.functions
     });
 
+    if (webglVersion > 1) {
+        report = _.extend(report, {
+            maxVertexUniformComponents: showNull(gl.getParameter(gl.MAX_VERTEX_UNIFORM_COMPONENTS)),
+            maxVertexUniformBlocks: showNull(gl.getParameter(gl.MAX_VERTEX_UNIFORM_BLOCKS)),
+            maxVertexOutputComponents: showNull(gl.getParameter(gl.MAX_VERTEX_OUTPUT_COMPONENTS)),
+            maxVaryingComponents: showNull(gl.getParameter(gl.MAX_VARYING_COMPONENTS)),
+            maxFragmentUniformComponents: showNull(gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_COMPONENTS)),
+            maxFragmentUniformBlocks: showNull(gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_BLOCKS)),
+            maxFragmentInputComponents: showNull(gl.getParameter(gl.MAX_FRAGMENT_INPUT_COMPONENTS)),
+            minProgramTexelOffset: showNull(gl.getParameter(gl.MIN_PROGRAM_TEXEL_OFFSET)),
+            maxProgramTexelOffset: showNull(gl.getParameter(gl.MAX_PROGRAM_TEXEL_OFFSET)),
+            maxDrawBuffers: showNull(gl.getParameter(gl.MAX_DRAW_BUFFERS)),
+            maxColorAttachments: showNull(gl.getParameter(gl.MAX_COLOR_ATTACHMENTS)),
+            maxSamples: showNull(gl.getParameter(gl.MAX_SAMPLES)),
+            max3dTextureSize: showNull(gl.getParameter(gl.MAX_3D_TEXTURE_SIZE)),
+            maxArrayTextureLayers: showNull(gl.getParameter(gl.MAX_ARRAY_TEXTURE_LAYERS)),
+            maxTextureLodBias: showNull(gl.getParameter(gl.MAX_TEXTURE_LOD_BIAS)),
+            maxUniformBufferBindings: showNull(gl.getParameter(gl.MAX_UNIFORM_BUFFER_BINDINGS)),
+            maxUniformBlockSize: showNull(gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE)),
+            uniformBufferOffsetAlignment: showNull(gl.getParameter(gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT)),
+            maxCombinedUniformBlocks: showNull(gl.getParameter(gl.MAX_COMBINED_UNIFORM_BLOCKS)),
+            maxCombinedVertexUniformComponents: showNull(gl.getParameter(gl.MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS)),
+            maxCombinedFragmentUniformComponents: showNull(gl.getParameter(gl.MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS)),
+            maxTransformFeedbackInterleavedComponents: showNull(gl.getParameter(gl.MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS)),
+            maxTransformFeedbackSeparateAttribs: showNull(gl.getParameter(gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS)),
+            maxTransformFeedbackSeparateComponents: showNull(gl.getParameter(gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS)),
+            maxElementIndex: showNull(gl.getParameter(gl.MAX_ELEMENT_INDEX)),
+            maxServerWaitTimeout: showNull(gl.getParameter(gl.MAX_SERVER_WAIT_TIMEOUT))
+        });
+    }
+
     if (window.externalHost) {
         // Tab is running with Chrome Frame
         renderReport($('#webglSupportedChromeFrameTemplate').html());
@@ -603,4 +638,6 @@ $(function() {
     drawDownArrow(vertexShaderBox, rasterizerBox);
     drawDownArrow(rasterizerBox, fragmentShaderBox);
     drawDownArrow(fragmentShaderBox, framebufferBox);
+
+    window.gl = gl;
 });

--- a/webglreport.js
+++ b/webglreport.js
@@ -87,7 +87,7 @@ $(function() {
             }
             return max;
         }
-        return null;
+        return 'n/a';
     }
 
     function formatPower(exponent, verbose) {

--- a/webglreport.js
+++ b/webglreport.js
@@ -488,6 +488,15 @@ $(function() {
         context.fill();
     }
 
+    function drawRightHead(x, y) {
+        context.beginPath();
+        context.moveTo(x - 5, y + 15);
+        context.lineTo(x + 10, y);
+        context.lineTo(x - 5, y - 15);
+        context.quadraticCurveTo(x, y, x - 5, y + 15);
+        context.fill();
+    }
+
     function drawDownHead(x, y) {
         context.beginPath();
         context.moveTo(x + 15, y - 5);
@@ -500,9 +509,9 @@ $(function() {
     function drawDownArrow(topBox, bottomBox) {
         context.beginPath();
 
-        var arrowTopX = (topBox.x + topBox.width) / 2;
+        var arrowTopX = topBox.x + topBox.width / 2;
         var arrowTopY = topBox.y + topBox.height;
-        var arrowBottomX = (bottomBox.x + bottomBox.width) / 2;
+        var arrowBottomX = bottomBox.x + bottomBox.width / 2;
         var arrowBottomY = bottomBox.y - 15;
         context.moveTo(arrowTopX, arrowTopY);
         context.lineTo(arrowBottomX, arrowBottomY);
@@ -511,18 +520,35 @@ $(function() {
         drawDownHead(arrowBottomX, arrowBottomY);
     }
 
+    function drawRightArrow(leftBox, rightBox) {
+        context.beginPath();
+
+        var arrowLeftX = leftBox.x + leftBox.width;
+        var arrowRightX = rightBox.x - 15;
+        var arrowRightY = rightBox.y + rightBox.height * 0.70;
+        context.moveTo(arrowLeftX, arrowRightY);
+        context.lineTo(arrowRightX, arrowRightY);
+        context.stroke();
+
+        drawRightHead(arrowRightX, arrowRightY);
+    }
+
+    var webgl2color = (webglVersion > 1) ? '#02AFCF' : '#aaa';
+
     var vertexShaderBox = drawBox($('.vertexShader'), '#ff6700');
+    var transformFeedbackBox = drawBox($('.transformFeedback'), webgl2color);
     var rasterizerBox = drawBox($('.rasterizer'), '#3130cb');
     var fragmentShaderBox = drawBox($('.fragmentShader'), '#ff6700');
     var framebufferBox = drawBox($('.framebuffer'), '#7c177e');
     var texturesBox = drawBox($('.textures'), '#3130cb');
+    var uniformBuffersBox = drawBox($('.uniformBuffers'), webgl2color);
 
     var arrowRightX = texturesBox.x;
     var arrowRightY = texturesBox.y + (texturesBox.height / 2);
     var arrowMidX = (texturesBox.x + vertexShaderBox.x + vertexShaderBox.width) / 2;
     var arrowMidY = arrowRightY;
     var arrowTopMidY = vertexShaderBox.y + (vertexShaderBox.height / 2);
-    var arrowBottomMidY = fragmentShaderBox.y + (fragmentShaderBox.height / 2);
+    var arrowBottomMidY = fragmentShaderBox.y + (fragmentShaderBox.height * 0.33);
     var arrowTopLeftX = vertexShaderBox.x + vertexShaderBox.width + 15;
     var arrowTopLeftY = arrowTopMidY;
     var arrowBottomLeftX = fragmentShaderBox.x + fragmentShaderBox.width + 15;
@@ -565,11 +591,16 @@ $(function() {
     context.lineTo(arrowMidX, arrowBottomMidY);
     context.lineTo(arrowBottomLeftX, arrowBottomLeftY);
 
+    var uniformBuffersMidY = uniformBuffersBox.y + uniformBuffersBox.height / 2;
+    context.moveTo(arrowMidX, uniformBuffersMidY);
+    context.lineTo(arrowRightX, uniformBuffersMidY);
+
     context.stroke();
 
     drawLeftHead(arrowBottomLeftX, arrowBottomLeftY);
 
-    drawDownArrow(vertexShaderBox, rasterizerBox);
+    drawDownArrow(vertexShaderBox, transformFeedbackBox);
+    drawDownArrow(transformFeedbackBox, rasterizerBox);
     drawDownArrow(rasterizerBox, fragmentShaderBox);
-    drawDownArrow(fragmentShaderBox, framebufferBox);
+    drawRightArrow(fragmentShaderBox, framebufferBox);
 });


### PR DESCRIPTION
Add separate "WebGL 1" and "WebGL 2" tabs at the top, and modify the pipeline to display a lot of new values from WebGL 2.

This fixes #26 and fixes #27.